### PR TITLE
fix: Add typing dependency for Python <= 3.10

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,6 +45,26 @@ jobs:
           python_version: '3.11.3'
           flags: ${{ matrix.flags }}
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: ${{ matrix.tools }}
+        uses: microsoft/action-python@0.6.3
+        with:
+          pytest: true
+          args: -m not integration and not cli
+          workdir: '.'
+          testdir: 'tests'
+          python_version: ${{ matrix.python }}
+          flags: unittests-${{ matrix.python }}
+
   publish:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   'requests',
   'pyyaml',
   'typing_extensions; python_version <= "3.10"',
+  'transformers; python_version <= "3.8"'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   'requests',
   'pyyaml',
   'typing_extensions; python_version <= "3.10"',
-  'transformers; python_version <= "3.8"'
+  'transformers; python_version < "3.9"'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,12 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8.1"
 dynamic = ["version"]
 dependencies = [
   'azure-identity',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10"
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
 ]
 requires-python = ">=3.7"
 dynamic = ["version"]
@@ -30,7 +31,8 @@ dependencies = [
   'knack',
   'openai',
   'requests',
-  "pyyaml",
+  'pyyaml',
+  'typing_extensions; python_version <= "3.10"',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   'requests',
   'pyyaml',
   'typing_extensions; python_version <= "3.10"',
-  'transformers; python_version < "3.9"'
+  'transformers; python_version <= "3.8"'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description
1. Set min Python version to 3.8.1 per [langchain](https://pypi.org/project/langchain/)
2. Add import for py<=3.10 to fix 'from typing import override'
3. Add transforms dep for py<=3.8 per missing dependency only for that version

<!-- Prefix the PR title with 'feat:' to increment the minor version, or 'fix:' to increment the patch version -->

<!-- Describe what changes this PR introduces and their effects -->
<!-- Update documentation if there are any changes to existing features or APIs -->

## Testing

<!-- Describe how you tested your changes and how reviewers can test them -->
<!-- Ensure all code can be tested offline (unmarked tests) and online (marked as 'integration') -->

## Additional context

<!-- Add any other context about your changes here -->

<!-- ## Breaking Changes -->

<!-- List any breaking changes introduced by this PR and their implications and include '!' in the prefix. -->
